### PR TITLE
feat: 增加VersionService用于获取当前服务器端实现的API版本

### DIFF
--- a/.changeset/cold-books-occur.md
+++ b/.changeset/cold-books-occur.md
@@ -1,0 +1,5 @@
+---
+"@scow/scow-scheduler-adapter-interface": minor
+---
+
+增加 VersionService，用于获取服务器当前实现的 API 版本

--- a/protos/version.proto
+++ b/protos/version.proto
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2022 Peking University and Peking University Institute for
+ * Computing and Digital Economy SCOW is licensed under Mulan PSL v2. You can
+ * use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY
+ * KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * NON-INFRINGEMENT, MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE. See the
+ * Mulan PSL v2 for more details.
+ */
+
+syntax = "proto3";
+
+package scow.scheduler_adapter;
+
+message GetVersionRequest {}
+
+message GetVersionResponse {
+  uint32 major = 1;
+  uint32 minor = 2;
+  uint32 patch = 3;
+}
+
+service VersionService {
+  /*
+    Get the version currently implemented by the server.
+  */
+  rpc GetVersion(GetVersionRequest) returns (GetVersionResponse);
+}


### PR DESCRIPTION
增加了VersionService，用于客户端获取服务器端实现的API版本。为了兼容性，客户端调用此接口返回NOT_IMPLEMENTED时，可以认为服务器端实现的版本为1.0.0或者1.0.1。