### PR TITLE
feat: 添加交互式应用接口用于获取容器内交互式应用的连接配置

### DIFF
--- a/.changeset/nasty-eggs-serve.md
+++ b/.changeset/nasty-eggs-serve.md
@@ -1,0 +1,5 @@
+---
+"@scow/scow-scheduler-adapter-interface": minor
+---
+
+添加交互式应用接口，添加 GetConnectionConfig 用于获取容器内交互式应用的连接配置

--- a/protos/app.proto
+++ b/protos/app.proto
@@ -1,0 +1,38 @@
+/**
+   * Copyright (c) 2022 Peking University and Peking University Institute for Computing and Digital Economy
+   * SCOW is licensed under Mulan PSL v2.
+   * You can use this software according to the terms and conditions of the Mulan PSL v2.
+   * You may obtain a copy of Mulan PSL v2 at:
+   *          http://license.coscl.org.cn/MulanPSL2
+   * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+   * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+   * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+   * See the Mulan PSL v2 for more details.
+*/
+
+syntax = "proto3";
+
+package scow.scheduler_adapter;
+
+message GetConnectionConfigRequest {
+  uint32 job_id = 1;
+}
+
+message GetConnectionConfigResponse {
+  optional string host = 1;
+  optional uint32 port = 2;
+  optional string password = 3;
+}
+
+service AppService {
+  /*
+   * description: get real connection config when connecting to an app
+   * special case: 
+   * - For interactive applications running on bare metal:
+   *   Directly use the configuration recorded in scow, so all fields can be empty.
+   * - For interactive applications running in containers:
+   *   This interface needs to provide the host and port information of the host machine to ensure scow can connect to the correct address.
+   *   Sometimes it needs to provide refreshed password for vnc app
+   */
+  rpc GetConnectionConfig(GetConnectionConfigRequest) returns (GetConnectionConfigResponse);
+}

--- a/protos/app.proto
+++ b/protos/app.proto
@@ -19,14 +19,14 @@ message GetAppConnectionInfoRequest {
 }
 
 message GetAppConnectionInfoResponse {
-  message UseScriptGenerated {}
+  message UseJobScriptGenerated {}
   message AppConnectionInfo {
     string host = 1;
     uint32 port = 2;
     string password = 3;
   }
   oneof response {
-    UseScriptGenerated use_script_generated = 1;
+    UseJobScriptGenerated use_job_script_generated = 1;
     AppConnectionInfo app_connection_info = 2;
   }
 }

--- a/protos/app.proto
+++ b/protos/app.proto
@@ -14,11 +14,11 @@ syntax = "proto3";
 
 package scow.scheduler_adapter;
 
-message GetConnectionConfigRequest {
+message GetAppConnectionInfoRequest {
   uint32 job_id = 1;
 }
 
-message GetConnectionConfigResponse {
+message GetAppConnectionInfoResponse {
   optional string host = 1;
   optional uint32 port = 2;
   optional string password = 3;
@@ -32,7 +32,7 @@ service AppService {
    *   Directly use the configuration recorded in scow, so all fields can be empty.
    * - For interactive applications running in containers:
    *   This interface needs to provide the host and port information of the host machine to ensure scow can connect to the correct address.
-   *   Sometimes it needs to provide refreshed password for vnc app
+   *   Sometimes it needs to provide password for app
    */
-  rpc GetConnectionConfig(GetConnectionConfigRequest) returns (GetConnectionConfigResponse);
+  rpc GetAppConnectionInfo(GetAppConnectionInfoRequest) returns (GetAppConnectionInfoResponse);
 }

--- a/protos/app.proto
+++ b/protos/app.proto
@@ -23,7 +23,7 @@ message GetAppConnectionInfoResponse {
   message AppConnectionInfo {
     string host = 1;
     uint32 port = 2;
-    optional string password = 3;
+    string password = 3;
   }
   oneof response {
     NoAppConnectionInfo no_info = 1;

--- a/protos/app.proto
+++ b/protos/app.proto
@@ -23,7 +23,7 @@ message GetAppConnectionInfoResponse {
   message AppConnectionInfo {
     string host = 1;
     uint32 port = 2;
-    string password = 3;
+    optional string password = 3;
   }
   oneof response {
     NoAppConnectionInfo no_info = 1;

--- a/protos/app.proto
+++ b/protos/app.proto
@@ -19,15 +19,15 @@ message GetAppConnectionInfoRequest {
 }
 
 message GetAppConnectionInfoResponse {
-  message NoAppConnectionInfo {}
+  message UseScriptGenerated {}
   message AppConnectionInfo {
     string host = 1;
     uint32 port = 2;
     string password = 3;
   }
   oneof response {
-    NoAppConnectionInfo no_info = 1;
-    AppConnectionInfo info = 2;
+    UseScriptGenerated use_script_generated = 1;
+    AppConnectionInfo app_connection_info = 2;
   }
 }
 

--- a/protos/app.proto
+++ b/protos/app.proto
@@ -19,9 +19,16 @@ message GetAppConnectionInfoRequest {
 }
 
 message GetAppConnectionInfoResponse {
-  optional string host = 1;
-  optional uint32 port = 2;
-  optional string password = 3;
+  message NoAppConnectionInfo {}
+  message AppConnectionInfo {
+    string host = 1;
+    uint32 port = 2;
+    string password = 3;
+  }
+  oneof response {
+    NoAppConnectionInfo no_info = 1;
+    AppConnectionInfo info = 2;
+  }
 }
 
 service AppService {


### PR DESCRIPTION
由于容器式的调度器启动的交互式应用运行在容器中, scow默认使用的host等信息来自于容器内部, 导致无法连接

添加接口`GetConnectionConfig`, 用于获取交互式应用启动后的实际`host`,`port`,`password`等信息