### PR TITLE
feat：提交文件脚本直接在调度器执行接口增加脚本文件所在绝对路径参数

### DIFF
--- a/.changeset/sixty-doors-thank.md
+++ b/.changeset/sixty-doors-thank.md
@@ -1,5 +1,5 @@
 ---
-"@scow/scow-scheduler-adapter-interface": patch
+"@scow/scow-scheduler-adapter-interface": minor
 ---
 
-在 submitScriptAsJob 下增加可选查询参数 script_file_full_path，当脚本内容中没有指定工作目录时，将脚本文件所在的绝对路径作为默认工作目录
+在 submitScriptAsJob 下增加可选请求参数script_file_full_path，当脚本内容中没有指定工作目录时，将脚本文件所在的绝对路径作为默认工作目录

--- a/.changeset/sixty-doors-thank.md
+++ b/.changeset/sixty-doors-thank.md
@@ -1,0 +1,5 @@
+---
+"@scow/scow-scheduler-adapter-interface": patch
+---
+
+在 submitScriptAsJob 下增加可选查询参数 script_file_full_path，当脚本内容中没有指定工作目录时，将脚本文件所在的绝对路径作为默认工作目录

--- a/protos/job.proto
+++ b/protos/job.proto
@@ -190,6 +190,8 @@ message CancelJobResponse {
 message SubmitScriptAsJobRequest {
   string user_id = 1;
   string script = 2;
+  // absolute path of the script file, used as job's work directory when not specified in script 
+  optional string script_file_full_path = 3;
 }
 
 message SubmitScriptAsJobResponse {


### PR DESCRIPTION
提交文件脚本直接在调度器执行接口SubmitScriptAsJob下增加脚本文件所在绝对路径参数script_file_full_path
当没有在脚本中指定作业工作路径时，使文件所在绝对路径作为默认工作路径