### PR TITLE
feat: 适配scow ai功能新增GetRunningJobNodeInfo接口以及SubmitJobRequest新增传参

### DIFF
--- a/.changeset/odd-rings-walk.md
+++ b/.changeset/odd-rings-walk.md
@@ -1,0 +1,5 @@
+---
+"@scow/scow-scheduler-adapter-interface": minor
+---
+
+SubmitJobRequest 增加可选参数 algorithm, dataset, image, model, mountPoint 以及增加 GetRunningJobNodeInfo 接口

--- a/protos/app.proto
+++ b/protos/app.proto
@@ -31,6 +31,17 @@ message GetAppConnectionInfoResponse {
   }
 }
 
+message GetRunningJobNodeInfoRequest {
+  uint32 job_id = 1;
+}
+
+message GetRunningJobNodeInfoResponse {
+  // 应用运行的节点
+  string node = 1;
+  // 应用运行的容器ID
+  string container_id = 2;
+}
+
 service AppService {
   /*
    * description: get real connection config when connecting to an app
@@ -42,4 +53,12 @@ service AppService {
    *   Sometimes it needs to provide password for app
    */
   rpc GetAppConnectionInfo(GetAppConnectionInfoRequest) returns (GetAppConnectionInfoResponse);
+
+    /*
+   * description: get interactive applications node info
+   * errors: 
+   * - job not found
+   *   NOT_FOUND, JOB_NOT_FOUND, {}
+   */
+   rpc GetRunningJobNodeInfo(GetRunningJobNodeInfoRequest) returns (GetRunningJobNodeInfoResponse);
 }

--- a/protos/job.proto
+++ b/protos/job.proto
@@ -172,10 +172,12 @@ message SubmitJobRequest {
   optional string stderr = 14;
   // extra options when submitting job
   repeated string extra_options = 15;
+
+  // algorithm, dataset, image, modal, mountPoint are file paths mounted to job running container
   optional string algorithm = 16;
   optional string dataset = 17;
   optional string image = 18;
-  // mount point of the respository
+  optional string model = 19;
   optional string mountPoint = 19;
 }
 

--- a/protos/job.proto
+++ b/protos/job.proto
@@ -178,7 +178,7 @@ message SubmitJobRequest {
   optional string dataset = 17;
   optional string image = 18;
   optional string model = 19;
-  optional string mountPoint = 20;
+  optional string mount_point = 20;
 }
 
 message SubmitJobResponse {

--- a/protos/job.proto
+++ b/protos/job.proto
@@ -178,7 +178,7 @@ message SubmitJobRequest {
   optional string dataset = 17;
   optional string image = 18;
   optional string model = 19;
-  optional string mountPoint = 19;
+  optional string mountPoint = 20;
 }
 
 message SubmitJobResponse {

--- a/protos/job.proto
+++ b/protos/job.proto
@@ -175,6 +175,8 @@ message SubmitJobRequest {
   optional string algorithm = 16;
   optional string dataset = 17;
   optional string image = 18;
+  // mount point of the respository
+  optional string mountPoint = 19;
 }
 
 message SubmitJobResponse {
@@ -201,16 +203,6 @@ message SubmitScriptAsJobResponse {
   uint32 job_id = 1;
 }
 
-message GetRunningJobNodeInfoRequest {
-  uint32 job_id = 1;
-}
-
-message GetRunningJobNodeInfoResponse {
-  // 应用运行的节点
-  string node = 1;
-  // 应用运行的容器ID
-  string container_id = 2;
-}
 
 service JobService {
   
@@ -280,11 +272,4 @@ service JobService {
    */
   rpc SubmitScriptAsJob(SubmitScriptAsJobRequest) returns (SubmitScriptAsJobResponse);
 
-  /*
-   * description: get running job node info
-   * errors: 
-   * - job not found
-   *   NOT_FOUND, JOB_NOT_FOUND, {}
-   */
-  rpc GetRunningJobNodeInfo(GetRunningJobNodeInfoRequest) returns (GetRunningJobNodeInfoResponse);
 }

--- a/protos/job.proto
+++ b/protos/job.proto
@@ -172,6 +172,9 @@ message SubmitJobRequest {
   optional string stderr = 14;
   // extra options when submitting job
   repeated string extra_options = 15;
+  optional string algorithm = 16;
+  optional string dataset = 17;
+  optional string image = 18;
 }
 
 message SubmitJobResponse {
@@ -196,6 +199,17 @@ message SubmitScriptAsJobRequest {
 
 message SubmitScriptAsJobResponse {
   uint32 job_id = 1;
+}
+
+message GetRunningJobNodeInfoRequest {
+  uint32 job_id = 1;
+}
+
+message GetRunningJobNodeInfoResponse {
+  // 应用运行的节点
+  string node = 1;
+  // 应用运行的pod
+  string pod = 2;
 }
 
 service JobService {
@@ -266,4 +280,11 @@ service JobService {
    */
   rpc SubmitScriptAsJob(SubmitScriptAsJobRequest) returns (SubmitScriptAsJobResponse);
 
+  /*
+   * description: get running job node info
+   * errors: 
+   * - job not found
+   *   NOT_FOUND, JOB_NOT_FOUND, {}
+   */
+  rpc GetRunningJobNodeInfo(GetRunningJobNodeInfoRequest) returns (GetRunningJobNodeInfoResponse);
 }

--- a/protos/job.proto
+++ b/protos/job.proto
@@ -208,8 +208,8 @@ message GetRunningJobNodeInfoRequest {
 message GetRunningJobNodeInfoResponse {
   // 应用运行的节点
   string node = 1;
-  // 应用运行的pod
-  string pod = 2;
+  // 应用运行的容器ID
+  string container_id = 2;
 }
 
 service JobService {


### PR DESCRIPTION
针对 scow for ai的功能，在创建应用时需要传algorithmdataset, image, model, mountPoint等参数，以上参数均为文件路径以供适配器将该目录映射进运行应用的容器中供用户使用

新增GetRunningJobNodeInfo， 可以在用户创建应用后， 需要将其保存镜像，SCOW AI需要获取应用具体运行在哪个节点以及具体的容器id，根据节点 ssh过去后对该id进行镜像打包并push到harbor上。