### PR TITLE
feat: 资源分区管理优化 

### DIFF
--- a/.changeset/big-plants-nail.md
+++ b/.changeset/big-plants-nail.md
@@ -2,9 +2,7 @@
 "@scow/scow-scheduler-adapter-interface": minor
 ---
 
-新增获取集群节点信息接口 GetClusterNodesInfo
 在 BlockAccountRequest 中增加兼容型参数 blocked_partitions
 在 UnBlockAccountRequest 中增加兼容型参数 unblocked_partitions
 在 GetAllAccountsWithUsersResponse 的返回值中变更 blocked 的注释，增加 account_blocked_details
 在 QueryAccountBlockStatusRequest 中增加兼容型参数 queried_partitions，Response中变更 blocked 的注释，增加 account_blocked_details
-在 getJobsRequest 中增加兼容型参数 job_id 和 job_name

--- a/.changeset/yellow-chefs-itch.md
+++ b/.changeset/yellow-chefs-itch.md
@@ -1,0 +1,5 @@
+---
+"@scow/scow-scheduler-adapter-interface": patch
+---
+
+在 GetClusterInfoResponse 中增加集群节点信息，作业信息等内容优化查询效率

--- a/protos/account.proto
+++ b/protos/account.proto
@@ -74,19 +74,19 @@ message AccountStatusInPartition {
 }
 
 message QueryAccountBlockStatusResponse {
-  // In versions 1.6.0 and earlier:
+  // In versions 1.7.0 and earlier:
   // - The account's status is uniformly consistent across all partitions by default.
   // - false: The queried account is unblocked in all partitions.
   // - true: The queried account has no available partitions.
 
-  // In versions later than 1.6.0:
+  // In versions later than 1.7.0:
   // - The field "blocked" represents whether the account is completely blocked across all partitions:
   // - true: The account is fully blocked in all partitions.
   // - false: The account has one or more partitions where it is not blocked.
   bool blocked = 1;
 
   // the details of account blocked status in every partition
-  // only returns in version later than 1.6.0
+  // only returns in version later than 1.7.0
   repeated AccountStatusInPartition account_blocked_details = 2;
 }
 
@@ -213,10 +213,10 @@ service AccountService {
   /*
    * description: query if an account is blocked
    * Version differences:
-   * - In versions 1.6.0 and earlier:
+   * - In versions 1.7.0 and earlier:
    * - The response's 'blocked' field indicates a uniform status across all partitions.
    * - The 'account_blocked_details' field is not returned.
-   * - In versions after 1.6.0:
+   * - In versions after 1.7.0:
    * - The 'blocked' field indicates whether the account is completely blocked across all partitions.
    * - The 'account_blocked_details' field provides detailed status information for each partition.
    * errors: 

--- a/protos/account.proto
+++ b/protos/account.proto
@@ -89,7 +89,7 @@ message DeleteAccountRequest {
 message DeleteAccountResponse {
 }
 
-// ********** Below is the interfaces for optional feature: resource management ***************
+// ********** Below is the interfaces for optional feature: RESOURCE_MANAGEMENT ***************
 message BlockAccountWithPartitionsRequest {
   string account_name = 1;
   // when the value exists: block specified partition(s) of the account
@@ -151,7 +151,7 @@ message GetAllAccountsWithUsersAndBlockedDetailsResponse {
   repeated ClusterAccountInfoWithBlockedDetails accounts = 1;
 }
 
-// ********** Above is the interfaces for optional feature: resource management ***************
+// ********** Above is the interfaces for optional feature: RESOURCE_MANAGEMENT ***************
 
 
 service AccountService {
@@ -218,9 +218,9 @@ service AccountService {
    rpc DeleteAccount(DeleteAccountRequest) returns (DeleteAccountResponse);
 
 
-   // ********** Below is the rpcs for optional feature: resource management ***************
+   // ********** Below is the rpcs for optional feature: RESOURCE_MANAGEMENT ***************
   /*  
-   * FOR OPTIOANL FEATURE: RESOURCE MANAGEMENT
+   * FOR OPTIOANL FEATURE: RESOURCE_MANAGEMENT
    * description: block an account with specified partitions
    * errors: 
    * - account not exist
@@ -230,7 +230,7 @@ service AccountService {
    */
    rpc BlockAccountWithPartitions(BlockAccountWithPartitionsRequest) returns (BlockAccountWithPartitionsResponse);
   /*
-   * FOR OPTIOANL FEATURE: RESOURCE MANAGEMENT
+   * FOR OPTIOANL FEATURE: RESOURCE_MANAGEMENT
    * description: unblock an account with specified partitions
    * errors: 
    * - account not exist
@@ -240,7 +240,7 @@ service AccountService {
    */
    rpc UnblockAccountWithPartitions(UnblockAccountWithPartitionsRequest) returns (UnblockAccountWithPartitionsResponse);
   /*
-   * FOR OPTIOANL FEATURE: RESOURCE MANAGEMENT
+   * FOR OPTIOANL FEATURE: RESOURCE_MANAGEMENT
    * description: query if an account is blocked with specified partitions
    * errors: 
    * - account not exist
@@ -248,11 +248,11 @@ service AccountService {
    */
    rpc QueryAccountBlockStatusWithPartitions(QueryAccountBlockStatusWithPartitionsRequest) returns (QueryAccountBlockStatusWithPartitionsResponse);
   /*
-   * FOR OPTIOANL FEATURE: RESOURCE MANAGEMENT
+   * FOR OPTIOANL FEATURE: RESOURCE_MANAGEMENT
    * description: get all accounts with blocked partitions' detail and all associated users 
    * special case:
    * - account no users, exclude this account
    */
    rpc GetAllAccountsWithUsersAndBlockedDetails(GetAllAccountsWithUsersAndBlockedDetailsRequest) returns (GetAllAccountsWithUsersAndBlockedDetailsResponse);
-   // ********** Above is the interfaces for optional feature: resource management ***************
+   // ********** Above is the interfaces for optional feature: RESOURCE_MANAGEMENT ***************
 }

--- a/protos/account.proto
+++ b/protos/account.proto
@@ -74,11 +74,19 @@ message AccountStatusInPartition {
 }
 
 message QueryAccountBlockStatusResponse {
-  // return the overall blocked_status in all partitions
-  // false: when the queried account has on or more available partitions
-  // true: when the queried account has no available partitions
+  // In versions 1.6.0 and earlier:
+  // - The account's status is uniformly consistent across all partitions by default.
+  // - false: The queried account is unblocked in all partitions.
+  // - true: The queried account has no available partitions.
+
+  // In versions later than 1.6.0:
+  // - The field "blocked" represents whether the account is completely blocked across all partitions:
+  // - true: The account is fully blocked in all partitions.
+  // - false: The account has one or more partitions where it is not blocked.
   bool blocked = 1;
+
   // the details of account blocked status in every partition
+  // only returns in version later than 1.6.0
   repeated AccountStatusInPartition account_blocked_details = 2;
 }
 
@@ -89,7 +97,9 @@ message DeleteAccountRequest {
 message DeleteAccountResponse {
 }
 
-// ********** Below is the interfaces for optional feature: RESOURCE_MANAGEMENT ***************
+
+
+// ************ Below is the interfaces for optional feature: RESOURCE_MANAGEMENT ***************
 message BlockAccountWithPartitionsRequest {
   string account_name = 1;
   // when the value exists: block specified partition(s) of the account
@@ -150,7 +160,6 @@ message GetAllAccountsWithUsersAndBlockedDetailsRequest {
 message GetAllAccountsWithUsersAndBlockedDetailsResponse {
   repeated ClusterAccountInfoWithBlockedDetails accounts = 1;
 }
-
 // ********** Above is the interfaces for optional feature: RESOURCE_MANAGEMENT ***************
 
 
@@ -203,6 +212,13 @@ service AccountService {
 
   /*
    * description: query if an account is blocked
+   * Version differences:
+   * - In versions 1.6.0 and earlier:
+   * - The response's 'blocked' field indicates a uniform status across all partitions.
+   * - The 'account_blocked_details' field is not returned.
+   * - In versions after 1.6.0:
+   * - The 'blocked' field indicates whether the account is completely blocked across all partitions.
+   * - The 'account_blocked_details' field provides detailed status information for each partition.
    * errors: 
    * - account not exist
    *   NOT_FOUND, ACCOUNT_NOT_FOUND, {}

--- a/protos/config.proto
+++ b/protos/config.proto
@@ -90,19 +90,20 @@ message NodeInfo {
   string node_name = 1;
   repeated string partitions = 2;
   string state = 3;
-  uint32 cpu_core_counts = 4;
-  uint32 alloc_cpu_core_counts = 5;
-  uint32 idle_cpu_core_counts = 6;
-  uint32 total_mem = 7;
-  uint32 alloc_mem = 8;
-  uint32 idle_mem = 9;
-  uint32 gpu_counts = 10;
-  uint32 alloc_gpu_counts = 11;
-  uint32 idle_gpu_counts = 12;
+  uint32 cpu_core_count = 4;
+  uint32 alloc_cpu_core_count = 5;
+  uint32 idle_cpu_core_count = 6;
+  uint32 total_mem_mb = 7;
+  uint32 alloc_mem_mb = 8;
+  uint32 idle_mem_mb = 9;
+  uint32 gpu_count = 10;
+  uint32 alloc_gpu_count = 11;
+  uint32 idle_gpu_count = 12;
 } 
 
 message GetClusterNodesInfoRequest {
-  repeated string nodes = 1;
+  // if the value of node_names = [], request all nodes info
+  repeated string node_names = 1;
 }
 
 message GetClusterNodesInfoResponse {

--- a/protos/config.proto
+++ b/protos/config.proto
@@ -84,7 +84,8 @@ message GetClusterInfoRequest {
 message GetClusterInfoResponse {
   string cluster_name = 1;
   repeated PartitionInfo partitions = 2;
-  // 3-17 Newly added parameters may not be returned
+  // 3-17 Newly added parameters
+  // only returns in version later than 1.7.0
   uint32 node_count = 3;
   uint32 running_node_count = 4;
   uint32 idle_node_count = 5;

--- a/protos/config.proto
+++ b/protos/config.proto
@@ -86,30 +86,6 @@ message GetClusterInfoResponse {
   repeated PartitionInfo partitions = 2;
 }
 
-message NodeInfo {
-  string node_name = 1;
-  repeated string partitions = 2;
-  string state = 3;
-  uint32 cpu_core_count = 4;
-  uint32 alloc_cpu_core_count = 5;
-  uint32 idle_cpu_core_count = 6;
-  uint32 total_mem_mb = 7;
-  uint32 alloc_mem_mb = 8;
-  uint32 idle_mem_mb = 9;
-  uint32 gpu_count = 10;
-  uint32 alloc_gpu_count = 11;
-  uint32 idle_gpu_count = 12;
-} 
-
-message GetClusterNodesInfoRequest {
-  // if the value of node_names = [], request all nodes info
-  repeated string node_names = 1;
-}
-
-message GetClusterNodesInfoResponse {
-  repeated NodeInfo nodes = 1;
-}
-
 service ConfigService {
   /*
    * description: get cluster config
@@ -123,8 +99,4 @@ service ConfigService {
    * description: get cluster information
    */
   rpc GetClusterInfo(GetClusterInfoRequest) returns (GetClusterInfoResponse);
-   /*
-   * description: get cluster nodes information
-   */
-  rpc GetClusterNodesInfo(GetClusterNodesInfoRequest) returns (GetClusterNodesInfoResponse);
 }

--- a/protos/job.proto
+++ b/protos/job.proto
@@ -104,6 +104,9 @@ message GetJobsRequest {
     optional TimeRange submit_time = 4;
     // if set this field, return jobs that ended between the time range(both endpoints included)
     optional TimeRange end_time = 5;
+
+    optional uint32 job_id = 6;
+    optional string job_name = 7;
   }
   // specify filter options
   optional Filter filter = 2;

--- a/protos/job.proto
+++ b/protos/job.proto
@@ -104,9 +104,6 @@ message GetJobsRequest {
     optional TimeRange submit_time = 4;
     // if set this field, return jobs that ended between the time range(both endpoints included)
     optional TimeRange end_time = 5;
-
-    optional uint32 job_id = 6;
-    optional string job_name = 7;
   }
   // specify filter options
   optional Filter filter = 2;
@@ -117,7 +114,6 @@ message GetJobsRequest {
 
   // returned jobs should be sorted if set
   optional SortInfo sort = 4;
-
 }
 
 message GetJobsResponse {


### PR DESCRIPTION
在 QueryAccountBlockStatus 的Response中变更 blocked 的注释，增加 account_blocked_details
在 ListImplementedOptionalFeatures 中增加可选功能枚举值
在 account.proto中增加可选功能rpc接口


在getClusterInfo的Response中增加
  // 3-17 Newly added parameters may not be returned
  uint32 node_count = 3;
  uint32 running_node_count = 4;
  uint32 idle_node_count = 5;
  uint32 not_available_node_count = 6;
  uint32 cpu_core_count =7;
  uint32 running_cpu_count = 8;
  uint32 idle_cpu_count = 9;
  uint32 not_available_cpu_count = 10;
  uint32 gpu_core_count = 11;
  uint32 running_gpu_count = 12;
  uint32 idle_gpu_count = 13;
  uint32 not_available_gpu_count = 14;
  uint32 job_count = 15;
  uint32 running_job_count = 16;
  uint32 pending_job_count = 17;
