### PR TITLE
feat: 增加获取支持的可选功能的接口

### DIFF
--- a/.changeset/wet-gorillas-do.md
+++ b/.changeset/wet-gorillas-do.md
@@ -1,0 +1,5 @@
+---
+"@scow/scow-scheduler-adapter-interface": minor
+---
+
+增加 ConfigService.ListImplementedOptionalFeatures RPC，用于获取适配器实现的可选功能

--- a/protos/config.proto
+++ b/protos/config.proto
@@ -118,6 +118,16 @@ message GetClusterNodesInfoResponse {
   repeated NodeInfo nodes = 1;
 }
 
+message ListImplementedOptionalFeaturesRequest {}
+
+enum OptionalFeatures {
+  UNKNOWN = 0;
+}
+
+message ListImplementedOptionalFeaturesResponse {
+  repeated OptionalFeatures features = 1;
+}
+
 service ConfigService {
   /*
    * description: get cluster config
@@ -135,4 +145,8 @@ service ConfigService {
    * description: get cluster nodes information
    */
   rpc GetClusterNodesInfo(GetClusterNodesInfoRequest) returns (GetClusterNodesInfoResponse);
+  /*
+   * description: List optional features implemented by this scheduler adapter
+   */
+   rpc ListImplementedOptionalFeatures(ListImplementedOptionalFeaturesRequest) returns (ListImplementedOptionalFeaturesResponse);
 }


### PR DESCRIPTION
增加 ConfigService.ListImplementedOptionalFeatures RPC，用于获取适配器实现的可选功能。

之后如果适配器需要增加可选功能，需要在enum OptionalFeatures下增加新的枚举项，并编写注释详细解释这个可选功能以及如何调用