### PR TITLE
fix: 修复 job_id int32 类型错误

### DIFF
--- a/.changeset/stupid-readers-exist.md
+++ b/.changeset/stupid-readers-exist.md
@@ -2,4 +2,4 @@
 "@scow/scow-scheduler-adapter-interface": minor
 ---
 
-修复 job_id int32 类型错误
+将 CancelJobRequest 中 job_id 字段从 int32 修改为 uint32

--- a/.changeset/stupid-readers-exist.md
+++ b/.changeset/stupid-readers-exist.md
@@ -1,5 +1,5 @@
 ---
-"@scow/scow-scheduler-adapter-interface": minor
+"@scow/scow-scheduler-adapter-interface": patch
 ---
 
 将 CancelJobRequest 中 job_id 字段从 int32 修改为 uint32

--- a/.changeset/stupid-readers-exist.md
+++ b/.changeset/stupid-readers-exist.md
@@ -1,0 +1,5 @@
+---
+"@scow/scow-scheduler-adapter-interface": minor
+---
+
+修复 job_id int32 类型错误

--- a/protos/job.proto
+++ b/protos/job.proto
@@ -184,7 +184,7 @@ message SubmitJobResponse {
 
 message CancelJobRequest {
   string user_id = 1;
-  int32 job_id = 2;
+  uint32 job_id = 2;
 }
 
 message CancelJobResponse {


### PR DESCRIPTION
CancelJobRequest 的 job id 为 int32 小于实际 uint32，故将其修改为 uint32