### PR TITLE
fix: 修改封锁/解封授权分区的注释信息

### DIFF
--- a/.changeset/heavy-points-rush.md
+++ b/.changeset/heavy-points-rush.md
@@ -1,0 +1,5 @@
+---
+"@scow/scow-scheduler-adapter-interface": patch
+---
+
+修改封锁/解封账户分区接口的注释

--- a/protos/account.proto
+++ b/protos/account.proto
@@ -103,7 +103,6 @@ message DeleteAccountResponse {
 message BlockAccountWithPartitionsRequest {
   string account_name = 1;
   // when the value exists: block specified partition(s) of the account
-  // when the value is [] or undefined: block the account in all partitions
   repeated string blocked_partitions = 2;
 }
 
@@ -113,7 +112,6 @@ message BlockAccountWithPartitionsResponse {
 message UnblockAccountWithPartitionsRequest {
   string account_name = 1;
   // specify the available partition(s) when executing unblock
-  // when the value is [] or undefined: use all partitions
   repeated string unblocked_partitions = 2;
 }
 


### PR DESCRIPTION
### 做了什么

在之前的设计中，封锁/解封分区为了兼容封/解封账户的时候默认没有数据参数则表示所有分区
但是实际实现上已经没有兼容逻辑，在调用接口前已经区分不同逻辑的判断
在调用封锁/解封分区接口时 不存在undefined的情况，如果为[]则按接口意义表示没有需要处理的分区的意思

此PR修改上述相关注释信息