### PR TITLE
feat(ai): 在PodStatus中增加新的状态枚举值

### DIFF
--- a/.changeset/clever-horses-tie.md
+++ b/.changeset/clever-horses-tie.md
@@ -1,0 +1,5 @@
+---
+"@scow/scow-scheduler-adapter-interface": patch
+---
+
+在 PodStatus 中增加新的容器状态 TIMEOUT 及 CONTAINER_CREATING

--- a/protos/job.proto
+++ b/protos/job.proto
@@ -37,6 +37,8 @@ message JobInfo {
     SUCCEEDED = 3;
     FAILED = 4;
     CANCELED = 5;
+    TIMEOUT = 6;
+    CONTAINER_CREATING = 7;
   }
 
   message PodInfo {


### PR DESCRIPTION
因为适配器最近要做一些关于AI作业状态的改动
在容器状态枚举值中增加新的状态值来保持某些状态一致，同时修复之前容器状态未解析在页面显示成`UNKNOWN`的问题
