### PR TITLE
feat: 支持获取分区实时AllowAccounts

### DIFF
--- a/protos/partition.proto
+++ b/protos/partition.proto
@@ -1,0 +1,30 @@
+/**
+   * Copyright (c) 2022 Peking University and Peking University Institute for Computing and Digital Economy
+   * SCOW is licensed under Mulan PSL v2.
+   * You can use this software according to the terms and conditions of the Mulan PSL v2.
+   * You may obtain a copy of Mulan PSL v2 at:
+   *          http://license.coscl.org.cn/MulanPSL2
+   * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+   * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+   * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+   * See the Mulan PSL v2 for more details.
+*/
+
+syntax = "proto3";
+
+package scow.scheduler_adapter;
+
+message GetPartitionsAllowAccountsRequest {
+
+}
+
+message GetPartitionsAllowAccountsResponse {
+  string partitions_allow_accounts_file_path = 1;
+}
+
+service PartitionService {
+  /*
+   * description: get partitions allow accounts
+   */
+  rpc GetPartitionsAllowAccounts(GetPartitionsAllowAccountsRequest) returns (GetPartitionsAllowAccountsResponse);
+}


### PR DESCRIPTION
提供一个接口，当用户想重启slurm时，先通过scow调用这个接口，将账户的分区AllowAccounts信息保存到一个文件中，然后将文件完整路径作为接口返回给用户，用户可以将该文件include进slurm.conf中，这样重启slurm后分区的AllowAccounts也不会丢失。